### PR TITLE
ui: improve logout link spacing and visibility

### DIFF
--- a/templates/problem_template.j2
+++ b/templates/problem_template.j2
@@ -32,7 +32,7 @@
         <a href="{{ url_for('login') }}">Login</a>
 	/ <a href="{{ url_for('register') }}">Sign up</a>
       {% else %}
-        {{ user.nickname }} <a href="{{ url_for('logout') }}">Logout</a>
+        {{ user.nickname }} <a href="{{ url_for('logout') }}" class="ml-4 opacity-80 hover:opacity-100 transition-opacity">Logout</a>
       {% endif %}
     </div>
   </div>


### PR DESCRIPTION
Fixes #49. Added a left margin to separate the logout link from the nickname and applied a subtle opacity transition for better hierarchy.