### PR TITLE
fix: center score content vertically in profile cards

### DIFF
--- a/templates/profile.j2
+++ b/templates/profile.j2
@@ -10,7 +10,7 @@
   <div class="md:p-8 p-4 grid grid-cols-1 md:grid-cols-3 md:gap-8 gap-4 md:min-h-[700px]">
     {%- for link, name, _ in problems %}
       <div class="p-4 text-center dark:bg-gray-900 bg-white rounded 
-                  ring-2 dark:ring-blue-500/50 grid grid-cols-1 ">
+                  ring-2 dark:ring-blue-500/50 grid grid-cols-1 content-center">
         <div>
 	  <a href="/problems/{{ link }}">
           <h2 class="mx-auto font-bold text-2xl">


### PR DESCRIPTION
## Summary

Fixes the vertical alignment of scores in user profile cards by adding `content-center` to the grid container.

## Changes

- Added `content-center` class to the score card grid container in `templates/profile.j2`
- This centers the content vertically within each card box using Tailwind's grid content alignment

## Before/After

**Before:** Scores were positioned too close to the top of the card
**After:** Scores are vertically centered within the card

Closes #84